### PR TITLE
(EDITORIAL) Minor punctuation fixes in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     ></script>
     <script type="text/javascript" class="remove">
       var respecConfig = {
-        // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
+        // specification status (e.g., WD, LCWD, NOTE, etc.). If in doubt use ED.
         specStatus: "CG-DRAFT",
 
         // the specification's short name, as in http://www.w3.org/TR/short-name/
@@ -409,7 +409,7 @@ section.
 <ul>
 <li>Enables other parties to obtain a copy of a <strong>list entry</strong>
 about an <strong>Issuer</strong> or <strong>Verifier</strong> from the
-<strong>list</strong>, e.g. in VC format, through DNS query, or other mechanism.
+<strong>list</strong>, e.g., in VC format, through DNS query, or other mechanism.
 <li>May or may not enable others to obtain a copy of the full contents of a
 <strong>list</strong>.
 <li>Those others may be anyone in the world, or they may be only those who have
@@ -680,7 +680,7 @@ formats such as a Verifiable Credential.
 DNS Resource Records, DNSSEC, on-chain Ethereum transactions, or other methods.
 <li>A list and its entries shall be cryptographically verifiable.
 <ul>
-<li>A list shall accommodate Different cryptographic mechanisms (X.509, JWK
+<li>A list shall accommodate Different cryptographic mechanisms (X.509, JWK,
 etc.).
 <li>There shall be an ability to authenticate the list or an individual entry.
 </li>
@@ -750,7 +750,7 @@ that represent entities or orgnaizations that provides services such as credenti
     <li><strong>LOElectronicAddress:</strong> Email address of the list operator.</li>
     <li><strong>LOWebSite:</strong> Website URI of the list operator.</li>
     <li><strong>ListName:</strong> Name under which the list operates.</li>
-    <li><strong>ListInformationURIs:</strong> Set of URIs for obtaining list-specific information, such as its scope, context, policies, rules etc.</li>
+    <li><strong>ListInformationURIs:</strong> Set of URIs for obtaining list-specific information, such as its scope, context, policies, rules, etc.</li>
     <li><strong>ListTerritory:</strong> Country or territory where the trusted list is established, preferably as ISO country codes.</li>
     <li><strong>PolicyOrLegalNotice:</strong> Policy or legal notice concerning the list's status or legal requirements.</li>
     <li><strong>IssuedAt:</strong> UTC date/time when the trusted list was issued.</li>


### PR DESCRIPTION
Noticed via #17.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/verifiable-issuers-verifiers/pull/18.html" title="Last updated on Apr 2, 2025, 9:34 PM UTC (dc7ed9c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/verifiable-issuers-verifiers/18/00e2846...TallTed:dc7ed9c.html" title="Last updated on Apr 2, 2025, 9:34 PM UTC (dc7ed9c)">Diff</a>